### PR TITLE
Fixes inconsistent handling of name parameter during serialization/deserialization in Preset class

### DIFF
--- a/packages/easy_onvif/lib/src/model/common/audio_encoder_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/audio_encoder_configuration.g.dart
@@ -9,13 +9,13 @@ part of 'audio_encoder_configuration.dart';
 AudioEncoderConfiguration _$AudioEncoderConfigurationFromJson(
         Map<String, dynamic> json) =>
     AudioEncoderConfiguration(
-      OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      OnvifUtil.mappedToString(json['Name']),
       OnvifUtil.mappedToInt(json['UseCount'] as Map<String, dynamic>),
-      OnvifUtil.mappedToString(json['Encoding'] as Map<String, dynamic>),
+      OnvifUtil.mappedToString(json['Encoding']),
       OnvifUtil.mappedToInt(json['Bitrate'] as Map<String, dynamic>),
       OnvifUtil.mappedToInt(json['SampleRate'] as Map<String, dynamic>),
       OnvifUtil.emptyMapToNull(json['Multicast'] as Map<String, dynamic>?),
-      OnvifUtil.mappedToString(json['SessionTimeout'] as Map<String, dynamic>),
+      OnvifUtil.mappedToString(json['SessionTimeout']),
     );
 
 Map<String, dynamic> _$AudioEncoderConfigurationToJson(

--- a/packages/easy_onvif/lib/src/model/common/audio_source_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/audio_source_configuration.g.dart
@@ -9,10 +9,9 @@ part of 'audio_source_configuration.dart';
 AudioSourceConfiguration _$AudioSourceConfigurationFromJson(
         Map<String, dynamic> json) =>
     AudioSourceConfiguration(
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       useCount: OnvifUtil.mappedToInt(json['UseCount'] as Map<String, dynamic>),
-      sourceToken:
-          OnvifUtil.mappedToString(json['SourceToken'] as Map<String, dynamic>),
+      sourceToken: OnvifUtil.mappedToString(json['SourceToken']),
     );
 
 Map<String, dynamic> _$AudioSourceConfigurationToJson(

--- a/packages/easy_onvif/lib/src/model/common/backlight_compensation.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/backlight_compensation.g.dart
@@ -9,7 +9,7 @@ part of 'backlight_compensation.dart';
 BacklightCompensation _$BacklightCompensationFromJson(
         Map<String, dynamic> json) =>
     BacklightCompensation(
-      mode: OnvifUtil.mappedToString(json['Mode'] as Map<String, dynamic>),
+      mode: OnvifUtil.mappedToString(json['Mode']),
       level: OnvifUtil.nullableMappedToDouble(
           json['Level'] as Map<String, dynamic>?),
     );

--- a/packages/easy_onvif/lib/src/model/common/exposure.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/exposure.g.dart
@@ -7,9 +7,8 @@ part of 'exposure.dart';
 // **************************************************************************
 
 Exposure _$ExposureFromJson(Map<String, dynamic> json) => Exposure(
-      mode: OnvifUtil.mappedToString(json['Mode'] as Map<String, dynamic>),
-      priority:
-          OnvifUtil.mappedToString(json['Priority'] as Map<String, dynamic>),
+      mode: OnvifUtil.mappedToString(json['Mode']),
+      priority: OnvifUtil.mappedToString(json['Priority']),
       window: Window.fromJson(json['Window'] as Map<String, dynamic>),
       minExposureTime: OnvifUtil.nullableMappedToDouble(
           json['MinExposureTime'] as Map<String, dynamic>?),

--- a/packages/easy_onvif/lib/src/model/common/h264.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/h264.g.dart
@@ -9,8 +9,7 @@ part of 'h264.dart';
 H264 _$H264FromJson(Map<String, dynamic> json) => H264(
       govLength:
           OnvifUtil.mappedToInt(json['GovLength'] as Map<String, dynamic>),
-      h264Profile:
-          OnvifUtil.mappedToString(json['H264Profile'] as Map<String, dynamic>),
+      h264Profile: OnvifUtil.mappedToString(json['H264Profile']),
     );
 
 Map<String, dynamic> _$H264ToJson(H264 instance) => <String, dynamic>{

--- a/packages/easy_onvif/lib/src/model/common/ip_address.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/ip_address.g.dart
@@ -7,7 +7,7 @@ part of 'ip_address.dart';
 // **************************************************************************
 
 IpAddress _$IpAddressFromJson(Map<String, dynamic> json) => IpAddress(
-      type: OnvifUtil.mappedToString(json['Type'] as Map<String, dynamic>),
+      type: OnvifUtil.mappedToString(json['Type']),
       ipv4Address: OnvifUtil.nullableMappedToString(
           json['IPv4Address'] as Map<String, dynamic>?),
       ipv6Address: OnvifUtil.nullableMappedToString(

--- a/packages/easy_onvif/lib/src/model/common/metadata_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/metadata_configuration.g.dart
@@ -10,7 +10,7 @@ MetadataConfiguration _$MetadataConfigurationFromJson(
         Map<String, dynamic> json) =>
     MetadataConfiguration(
       token: json['@token'] as String,
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       useCount: OnvifUtil.mappedToInt(json['UseCount'] as Map<String, dynamic>),
       compressionType: json['CompressionType'] as String?,
       geoLocation: json['GeoLocation'] as bool?,
@@ -25,8 +25,7 @@ MetadataConfiguration _$MetadataConfigurationFromJson(
           json['Analytics'] as Map<String, dynamic>?),
       multicast:
           OnvifUtil.emptyMapToNull(json['Multicast'] as Map<String, dynamic>?),
-      sessionTimeout: OnvifUtil.mappedToString(
-          json['SessionTimeout'] as Map<String, dynamic>),
+      sessionTimeout: OnvifUtil.mappedToString(json['SessionTimeout']),
       analyticsEngineConfiguration:
           json['AnalyticsEngineConfiguration'] as Map<String, dynamic>?,
       extension: json['Extension'] as Map<String, dynamic>?,

--- a/packages/easy_onvif/lib/src/model/common/mixed_profile.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/mixed_profile.g.dart
@@ -9,7 +9,7 @@ part of 'mixed_profile.dart';
 MixedProfile _$MixedProfileFromJson(Map<String, dynamic> json) => MixedProfile(
       token: json['@token'] as String,
       fixed: OnvifUtil.nullableStringToBool(json['@fixed'] as String?),
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       configurations: json['Configurations'] == null
           ? null
           : ConfigurationSet.fromJson(

--- a/packages/easy_onvif/lib/src/model/common/mpeg4.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/mpeg4.g.dart
@@ -9,8 +9,7 @@ part of 'mpeg4.dart';
 Mpeg4 _$Mpeg4FromJson(Map<String, dynamic> json) => Mpeg4(
       govLength:
           OnvifUtil.mappedToInt(json['GovLength'] as Map<String, dynamic>),
-      mpeg4Profile: OnvifUtil.mappedToString(
-          json['Mpeg4Profile'] as Map<String, dynamic>),
+      mpeg4Profile: OnvifUtil.mappedToString(json['Mpeg4Profile']),
     );
 
 Map<String, dynamic> _$Mpeg4ToJson(Mpeg4 instance) => <String, dynamic>{

--- a/packages/easy_onvif/lib/src/model/common/ptz_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/ptz_configuration.g.dart
@@ -9,7 +9,7 @@ part of 'ptz_configuration.dart';
 PtzConfiguration _$PtzConfigurationFromJson(Map<String, dynamic> json) =>
     PtzConfiguration(
       token: json['@token'] as String,
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       useCount: OnvifUtil.mappedToInt(json['UseCount'] as Map<String, dynamic>),
       moveRamp: OnvifUtil.nullableMappedToInt(
           json['MoveRamp'] as Map<String, dynamic>?),
@@ -17,8 +17,7 @@ PtzConfiguration _$PtzConfigurationFromJson(Map<String, dynamic> json) =>
           json['PresetRamp'] as Map<String, dynamic>?),
       presetTourRamp: OnvifUtil.nullableMappedToInt(
           json['PresetTourRamp'] as Map<String, dynamic>?),
-      nodeToken:
-          OnvifUtil.mappedToString(json['NodeToken'] as Map<String, dynamic>),
+      nodeToken: OnvifUtil.mappedToString(json['NodeToken']),
       defaultAbsolutePantTiltPositionSpace:
           PtzConfiguration._nullableMappedToSpace(
               json['DefaultAbsolutePantTiltPositionSpace']

--- a/packages/easy_onvif/lib/src/model/common/space_1d.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/space_1d.g.dart
@@ -7,7 +7,7 @@ part of 'space_1d.dart';
 // **************************************************************************
 
 Space1D _$Space1DFromJson(Map<String, dynamic> json) => Space1D(
-      uri: OnvifUtil.mappedToString(json['URI'] as Map<String, dynamic>),
+      uri: OnvifUtil.mappedToString(json['URI']),
       xRange: FloatRange.fromJson(json['XRange'] as Map<String, dynamic>),
     );
 

--- a/packages/easy_onvif/lib/src/model/common/space_2d.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/space_2d.g.dart
@@ -7,7 +7,7 @@ part of 'space_2d.dart';
 // **************************************************************************
 
 Space2D _$Space2DFromJson(Map<String, dynamic> json) => Space2D(
-      uri: OnvifUtil.mappedToString(json['URI'] as Map<String, dynamic>),
+      uri: OnvifUtil.mappedToString(json['URI']),
       xRange: FloatRange.fromJson(json['XRange'] as Map<String, dynamic>),
       yRange: FloatRange.fromJson(json['YRange'] as Map<String, dynamic>),
     );

--- a/packages/easy_onvif/lib/src/model/common/video_analytics_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/video_analytics_configuration.g.dart
@@ -9,7 +9,7 @@ part of 'video_analytics_configuration.dart';
 VideoAnalyticsConfiguration _$VideoAnalyticsConfigurationFromJson(
         Map<String, dynamic> json) =>
     VideoAnalyticsConfiguration(
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       useCount: OnvifUtil.mappedToInt(json['UseCount'] as Map<String, dynamic>),
     );
 

--- a/packages/easy_onvif/lib/src/model/common/video_encoder_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/video_encoder_configuration.g.dart
@@ -10,7 +10,7 @@ VideoEncoderConfiguration _$VideoEncoderConfigurationFromJson(
         Map<String, dynamic> json) =>
     VideoEncoderConfiguration(
       token: json['@token'] as String,
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       useCount: OnvifUtil.mappedToInt(json['UseCount'] as Map<String, dynamic>),
       encoding: OnvifUtil.nullableMappedToString(
           json['Encoding'] as Map<String, dynamic>?),

--- a/packages/easy_onvif/lib/src/model/common/video_source_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/video_source_configuration.g.dart
@@ -10,10 +10,9 @@ VideoSourceConfiguration _$VideoSourceConfigurationFromJson(
         Map<String, dynamic> json) =>
     VideoSourceConfiguration(
       token: json['@token'] as String,
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       useCount: OnvifUtil.mappedToInt(json['UseCount'] as Map<String, dynamic>),
-      sourceToken:
-          OnvifUtil.mappedToString(json['SourceToken'] as Map<String, dynamic>),
+      sourceToken: OnvifUtil.mappedToString(json['SourceToken']),
       bounds: IntRectangle.fromJson(json['Bounds'] as Map<String, dynamic>),
       extension: json['Extension'],
     );

--- a/packages/easy_onvif/lib/src/model/common/white_balance.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/white_balance.g.dart
@@ -7,7 +7,7 @@ part of 'white_balance.dart';
 // **************************************************************************
 
 WhiteBalance _$WhiteBalanceFromJson(Map<String, dynamic> json) => WhiteBalance(
-      mode: OnvifUtil.mappedToString(json['Mode'] as Map<String, dynamic>),
+      mode: OnvifUtil.mappedToString(json['Mode']),
       crGain: OnvifUtil.mappedToDouble(json['CrGain'] as Map<String, dynamic>),
       cbGain: OnvifUtil.mappedToDouble(json['CbGain'] as Map<String, dynamic>),
     );

--- a/packages/easy_onvif/lib/src/model/common/wide_dynamic_range.g.dart
+++ b/packages/easy_onvif/lib/src/model/common/wide_dynamic_range.g.dart
@@ -8,7 +8,7 @@ part of 'wide_dynamic_range.dart';
 
 WideDynamicRange _$WideDynamicRangeFromJson(Map<String, dynamic> json) =>
     WideDynamicRange(
-      mode: OnvifUtil.mappedToString(json['Mode'] as Map<String, dynamic>),
+      mode: OnvifUtil.mappedToString(json['Mode']),
       level: OnvifUtil.mappedToDouble(json['Level'] as Map<String, dynamic>),
     );
 

--- a/packages/easy_onvif/lib/src/model/device_management/analytics_capabilities.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/analytics_capabilities.g.dart
@@ -9,7 +9,7 @@ part of 'analytics_capabilities.dart';
 AnalyticsCapabilities _$AnalyticsCapabilitiesFromJson(
         Map<String, dynamic> json) =>
     AnalyticsCapabilities(
-      OnvifUtil.mappedToString(json['XAddr'] as Map<String, dynamic>),
+      OnvifUtil.mappedToString(json['XAddr']),
       OnvifUtil.mappedToBool(json['RuleSupport'] as Map<String, dynamic>),
       OnvifUtil.mappedToBool(
           json['AnalyticsModuleSupport'] as Map<String, dynamic>),

--- a/packages/easy_onvif/lib/src/model/device_management/device_capabilities.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/device_capabilities.g.dart
@@ -8,7 +8,7 @@ part of 'device_capabilities.dart';
 
 DeviceCapabilities _$DeviceCapabilitiesFromJson(Map<String, dynamic> json) =>
     DeviceCapabilities(
-      xAddr: OnvifUtil.mappedToString(json['XAddr'] as Map<String, dynamic>),
+      xAddr: OnvifUtil.mappedToString(json['XAddr']),
       network: json['Network'] == null
           ? null
           : NetworkCapabilities.fromJson(

--- a/packages/easy_onvif/lib/src/model/device_management/dns_entry.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/dns_entry.g.dart
@@ -7,7 +7,7 @@ part of 'dns_entry.dart';
 // **************************************************************************
 
 DnsEntry _$DnsEntryFromJson(Map<String, dynamic> json) => DnsEntry(
-      type: OnvifUtil.mappedToString(json['Type'] as Map<String, dynamic>),
+      type: OnvifUtil.mappedToString(json['Type']),
       ipv4Address: OnvifUtil.nullableMappedToString(
           json['IPv4Address'] as Map<String, dynamic>?),
       ipv6Address: OnvifUtil.nullableMappedToString(

--- a/packages/easy_onvif/lib/src/model/device_management/event_capabilities.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/event_capabilities.g.dart
@@ -8,7 +8,7 @@ part of 'event_capabilities.dart';
 
 EventCapabilities _$EventCapabilitiesFromJson(Map<String, dynamic> json) =>
     EventCapabilities(
-      OnvifUtil.mappedToString(json['XAddr'] as Map<String, dynamic>),
+      OnvifUtil.mappedToString(json['XAddr']),
     );
 
 Map<String, dynamic> _$EventCapabilitiesToJson(EventCapabilities instance) =>

--- a/packages/easy_onvif/lib/src/model/device_management/get_device_information_response.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/get_device_information_response.g.dart
@@ -12,9 +12,9 @@ GetDeviceInformationResponse _$GetDeviceInformationResponseFromJson(
       OnvifUtil.nullableMappedToString(
           json['Manufacturer'] as Map<String, dynamic>?),
       OnvifUtil.nullableMappedToString(json['Model'] as Map<String, dynamic>?),
-      OnvifUtil.mappedToString(json['FirmwareVersion'] as Map<String, dynamic>),
-      OnvifUtil.mappedToString(json['SerialNumber'] as Map<String, dynamic>),
-      OnvifUtil.mappedToString(json['HardwareId'] as Map<String, dynamic>),
+      OnvifUtil.mappedToString(json['FirmwareVersion']),
+      OnvifUtil.mappedToString(json['SerialNumber']),
+      OnvifUtil.mappedToString(json['HardwareId']),
     );
 
 Map<String, dynamic> _$GetDeviceInformationResponseToJson(

--- a/packages/easy_onvif/lib/src/model/device_management/get_discovery_mode_response.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/get_discovery_mode_response.g.dart
@@ -9,7 +9,7 @@ part of 'get_discovery_mode_response.dart';
 GetDiscoveryModeResponse _$GetDiscoveryModeResponseFromJson(
         Map<String, dynamic> json) =>
     GetDiscoveryModeResponse(
-      OnvifUtil.mappedToString(json['DiscoveryMode'] as Map<String, dynamic>),
+      OnvifUtil.mappedToString(json['DiscoveryMode']),
     );
 
 Map<String, dynamic> _$GetDiscoveryModeResponseToJson(

--- a/packages/easy_onvif/lib/src/model/device_management/hostname_information.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/hostname_information.g.dart
@@ -8,9 +8,8 @@ part of 'hostname_information.dart';
 
 HostnameInformation _$HostnameInformationFromJson(Map<String, dynamic> json) =>
     HostnameInformation(
-      fromDhcp:
-          OnvifUtil.mappedToString(json['FromDHCP'] as Map<String, dynamic>),
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      fromDhcp: OnvifUtil.mappedToString(json['FromDHCP']),
+      name: OnvifUtil.mappedToString(json['Name']),
     );
 
 Map<String, dynamic> _$HostnameInformationToJson(

--- a/packages/easy_onvif/lib/src/model/device_management/imaging_capabilities.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/imaging_capabilities.g.dart
@@ -8,7 +8,7 @@ part of 'imaging_capabilities.dart';
 
 ImagingCapabilities _$ImagingCapabilitiesFromJson(Map<String, dynamic> json) =>
     ImagingCapabilities(
-      xAddr: OnvifUtil.mappedToString(json['XAddr'] as Map<String, dynamic>),
+      xAddr: OnvifUtil.mappedToString(json['XAddr']),
     );
 
 Map<String, dynamic> _$ImagingCapabilitiesToJson(

--- a/packages/easy_onvif/lib/src/model/device_management/media_capabilities.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/media_capabilities.g.dart
@@ -8,7 +8,7 @@ part of 'media_capabilities.dart';
 
 MediaCapabilities _$MediaCapabilitiesFromJson(Map<String, dynamic> json) =>
     MediaCapabilities(
-      xAddr: OnvifUtil.mappedToString(json['XAddr'] as Map<String, dynamic>),
+      xAddr: OnvifUtil.mappedToString(json['XAddr']),
       streamingCapabilities: RealTimeStreamingCapabilities.fromJson(
           json['StreamingCapabilities'] as Map<String, dynamic>),
     );

--- a/packages/easy_onvif/lib/src/model/device_management/network_protocol.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/network_protocol.g.dart
@@ -8,7 +8,7 @@ part of 'network_protocol.dart';
 
 NetworkProtocol _$NetworkProtocolFromJson(Map<String, dynamic> json) =>
     NetworkProtocol(
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       enabled: OnvifUtil.mappedToBool(json['Enabled'] as Map<String, dynamic>),
       port: OnvifUtil.mappedToInt(json['Port'] as Map<String, dynamic>),
     );

--- a/packages/easy_onvif/lib/src/model/device_management/ntp.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/ntp.g.dart
@@ -7,7 +7,7 @@ part of 'ntp.dart';
 // **************************************************************************
 
 Ntp _$NtpFromJson(Map<String, dynamic> json) => Ntp(
-      type: OnvifUtil.mappedToString(json['Type'] as Map<String, dynamic>),
+      type: OnvifUtil.mappedToString(json['Type']),
       iPv4Address: OnvifUtil.nullableMappedToString(
           json['IPv4Address'] as Map<String, dynamic>?),
       iPv6Address: OnvifUtil.nullableMappedToString(

--- a/packages/easy_onvif/lib/src/model/device_management/ptz_capabilities.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/ptz_capabilities.g.dart
@@ -8,7 +8,7 @@ part of 'ptz_capabilities.dart';
 
 PtzCapabilities _$PtzCapabilitiesFromJson(Map<String, dynamic> json) =>
     PtzCapabilities(
-      xAddr: OnvifUtil.mappedToString(json['XAddr'] as Map<String, dynamic>),
+      xAddr: OnvifUtil.mappedToString(json['XAddr']),
     );
 
 Map<String, dynamic> _$PtzCapabilitiesToJson(PtzCapabilities instance) =>

--- a/packages/easy_onvif/lib/src/model/device_management/service.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/service.g.dart
@@ -7,9 +7,8 @@ part of 'service.dart';
 // **************************************************************************
 
 Service _$ServiceFromJson(Map<String, dynamic> json) => Service(
-      nameSpace:
-          OnvifUtil.mappedToString(json['Namespace'] as Map<String, dynamic>),
-      xAddr: OnvifUtil.mappedToString(json['XAddr'] as Map<String, dynamic>),
+      nameSpace: OnvifUtil.mappedToString(json['Namespace']),
+      xAddr: OnvifUtil.mappedToString(json['XAddr']),
       version: Version.fromJson(json['Version'] as Map<String, dynamic>),
       capabilities: json['Capabilities'] == null
           ? null

--- a/packages/easy_onvif/lib/src/model/device_management/system_log_uri.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/system_log_uri.g.dart
@@ -7,7 +7,7 @@ part of 'system_log_uri.dart';
 // **************************************************************************
 
 SystemLogUri _$SystemLogUriFromJson(Map<String, dynamic> json) => SystemLogUri(
-      type: OnvifUtil.mappedToString(json['Type'] as Map<String, dynamic>),
+      type: OnvifUtil.mappedToString(json['Type']),
       uri: OnvifUtil.nullableMappedToString(
           json['Uri'] as Map<String, dynamic>?),
     );

--- a/packages/easy_onvif/lib/src/model/device_management/system_reboot_response.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/system_reboot_response.g.dart
@@ -9,8 +9,7 @@ part of 'system_reboot_response.dart';
 SystemRebootResponse _$SystemRebootResponseFromJson(
         Map<String, dynamic> json) =>
     SystemRebootResponse(
-      message:
-          OnvifUtil.mappedToString(json['Message'] as Map<String, dynamic>),
+      message: OnvifUtil.mappedToString(json['Message']),
     );
 
 Map<String, dynamic> _$SystemRebootResponseToJson(

--- a/packages/easy_onvif/lib/src/model/device_management/user.g.dart
+++ b/packages/easy_onvif/lib/src/model/device_management/user.g.dart
@@ -7,8 +7,7 @@ part of 'user.dart';
 // **************************************************************************
 
 User _$UserFromJson(Map<String, dynamic> json) => User(
-      username:
-          OnvifUtil.mappedToString(json['Username'] as Map<String, dynamic>),
+      username: OnvifUtil.mappedToString(json['Username']),
       password: OnvifUtil.nullableMappedToString(
           json['Password'] as Map<String, dynamic>?),
       userLevel:

--- a/packages/easy_onvif/lib/src/model/imaging/focus_status_20.g.dart
+++ b/packages/easy_onvif/lib/src/model/imaging/focus_status_20.g.dart
@@ -10,8 +10,7 @@ FocusStatus20 _$FocusStatus20FromJson(Map<String, dynamic> json) =>
     FocusStatus20(
       position:
           OnvifUtil.mappedToDouble(json['Position'] as Map<String, dynamic>),
-      moveStatus:
-          OnvifUtil.mappedToString(json['MoveStatus'] as Map<String, dynamic>),
+      moveStatus: OnvifUtil.mappedToString(json['MoveStatus']),
       error: OnvifUtil.nullableMappedToString(
           json['Error'] as Map<String, dynamic>?),
       extension: json['Extension'] as Map<String, dynamic>?,

--- a/packages/easy_onvif/lib/src/model/imaging/imaging_preset.g.dart
+++ b/packages/easy_onvif/lib/src/model/imaging/imaging_preset.g.dart
@@ -9,8 +9,8 @@ part of 'imaging_preset.dart';
 ImagingPreset _$ImagingPresetFromJson(Map<String, dynamic> json) =>
     ImagingPreset(
       token: json['@token'] as String,
-      type: OnvifUtil.mappedToString(json['type'] as Map<String, dynamic>),
-      name: OnvifUtil.mappedToString(json['name'] as Map<String, dynamic>),
+      type: OnvifUtil.mappedToString(json['type']),
+      name: OnvifUtil.mappedToString(json['name']),
     );
 
 Map<String, dynamic> _$ImagingPresetToJson(ImagingPreset instance) =>

--- a/packages/easy_onvif/lib/src/model/media1/media_uri.g.dart
+++ b/packages/easy_onvif/lib/src/model/media1/media_uri.g.dart
@@ -7,13 +7,12 @@ part of 'media_uri.dart';
 // **************************************************************************
 
 MediaUri _$MediaUriFromJson(Map<String, dynamic> json) => MediaUri(
-      uri: OnvifUtil.mappedToString(json['Uri'] as Map<String, dynamic>),
+      uri: OnvifUtil.mappedToString(json['Uri']),
       invalidAfterConnect: OnvifUtil.mappedToBool(
           json['InvalidAfterConnect'] as Map<String, dynamic>),
       invalidAfterReboot: OnvifUtil.mappedToBool(
           json['InvalidAfterReboot'] as Map<String, dynamic>),
-      timeout:
-          OnvifUtil.mappedToString(json['Timeout'] as Map<String, dynamic>),
+      timeout: OnvifUtil.mappedToString(json['Timeout']),
     );
 
 Map<String, dynamic> _$MediaUriToJson(MediaUri instance) => <String, dynamic>{

--- a/packages/easy_onvif/lib/src/model/media1/profile.g.dart
+++ b/packages/easy_onvif/lib/src/model/media1/profile.g.dart
@@ -9,7 +9,7 @@ part of 'profile.dart';
 Profile _$ProfileFromJson(Map<String, dynamic> json) => Profile(
       token: json['@token'] as String,
       fixed: OnvifUtil.stringToBool(json['@fixed'] as String),
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       videoSourceConfiguration: json['VideoSourceConfiguration'] == null
           ? null
           : VideoSourceConfiguration.fromJson(

--- a/packages/easy_onvif/lib/src/model/media1/video_source.g.dart
+++ b/packages/easy_onvif/lib/src/model/media1/video_source.g.dart
@@ -8,8 +8,7 @@ part of 'video_source.dart';
 
 VideoSource _$VideoSourceFromJson(Map<String, dynamic> json) => VideoSource(
       token: json['@token'] as String,
-      frameRate:
-          OnvifUtil.mappedToString(json['Framerate'] as Map<String, dynamic>),
+      frameRate: OnvifUtil.mappedToString(json['Framerate']),
       resolution:
           VideoResolution.fromJson(json['Resolution'] as Map<String, dynamic>),
       imaging: json['Imaging'] == null

--- a/packages/easy_onvif/lib/src/model/media2/codec.g.dart
+++ b/packages/easy_onvif/lib/src/model/media2/codec.g.dart
@@ -7,8 +7,7 @@ part of 'codec.dart';
 // **************************************************************************
 
 Codec _$CodecFromJson(Map<String, dynamic> json) => Codec(
-      encoding:
-          OnvifUtil.mappedToString(json['Encoding'] as Map<String, dynamic>),
+      encoding: OnvifUtil.mappedToString(json['Encoding']),
       number: OnvifUtil.mappedToInt(json['Number'] as Map<String, dynamic>),
     );
 

--- a/packages/easy_onvif/lib/src/model/media2/get_snapshot_uri_response.g.dart
+++ b/packages/easy_onvif/lib/src/model/media2/get_snapshot_uri_response.g.dart
@@ -9,7 +9,7 @@ part of 'get_snapshot_uri_response.dart';
 GetSnapshotUriResponse _$GetSnapshotUriResponseFromJson(
         Map<String, dynamic> json) =>
     GetSnapshotUriResponse(
-      uri: OnvifUtil.mappedToString(json['Uri'] as Map<String, dynamic>),
+      uri: OnvifUtil.mappedToString(json['Uri']),
     );
 
 Map<String, dynamic> _$GetSnapshotUriResponseToJson(

--- a/packages/easy_onvif/lib/src/model/media2/get_stream_uri_response.g.dart
+++ b/packages/easy_onvif/lib/src/model/media2/get_stream_uri_response.g.dart
@@ -9,7 +9,7 @@ part of 'get_stream_uri_response.dart';
 GetStreamUriResponse _$GetStreamUriResponseFromJson(
         Map<String, dynamic> json) =>
     GetStreamUriResponse(
-      uri: OnvifUtil.mappedToString(json['Uri'] as Map<String, dynamic>),
+      uri: OnvifUtil.mappedToString(json['Uri']),
     );
 
 Map<String, dynamic> _$GetStreamUriResponseToJson(

--- a/packages/easy_onvif/lib/src/model/media2/media_profile.g.dart
+++ b/packages/easy_onvif/lib/src/model/media2/media_profile.g.dart
@@ -9,7 +9,7 @@ part of 'media_profile.dart';
 MediaProfile _$MediaProfileFromJson(Map<String, dynamic> json) => MediaProfile(
       token: json['@token'] as String,
       fixed: OnvifUtil.nullableStringToBool(json['@fixed'] as String?),
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       configurations: json['Configurations'] == null
           ? null
           : ConfigurationSet.fromJson(

--- a/packages/easy_onvif/lib/src/model/media2/video_encoder2_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/media2/video_encoder2_configuration.g.dart
@@ -10,7 +10,7 @@ VideoEncoder2Configuration _$VideoEncoder2ConfigurationFromJson(
         Map<String, dynamic> json) =>
     VideoEncoder2Configuration(
       token: json['@token'] as String,
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       useCount: OnvifUtil.mappedToInt(json['UseCount'] as Map<String, dynamic>),
       govLength: int.parse(json['@GovLength'] as String),
       anchorFrameDistance: OnvifUtil.nullableMappedToInt(
@@ -18,8 +18,7 @@ VideoEncoder2Configuration _$VideoEncoder2ConfigurationFromJson(
       profile: json['@Profile'] as String,
       guaranteedFrameRate: OnvifUtil.nullableMappedToBool(
           json['GuaranteedFrameRate'] as Map<String, dynamic>?),
-      encoding:
-          OnvifUtil.mappedToString(json['Encoding'] as Map<String, dynamic>),
+      encoding: OnvifUtil.mappedToString(json['Encoding']),
       resolution:
           VideoResolution2.fromJson(json['Resolution'] as Map<String, dynamic>),
       rateControl: VideoRateControl2.fromJson(

--- a/packages/easy_onvif/lib/src/model/media_uri.g.dart
+++ b/packages/easy_onvif/lib/src/model/media_uri.g.dart
@@ -7,13 +7,12 @@ part of 'media_uri.dart';
 // **************************************************************************
 
 MediaUri _$MediaUriFromJson(Map<String, dynamic> json) => MediaUri(
-      uri: OnvifUtil.mappedToString(json['Uri'] as Map<String, dynamic>),
+      uri: OnvifUtil.mappedToString(json['Uri']),
       invalidAfterConnect: OnvifUtil.mappedToBool(
           json['InvalidAfterConnect'] as Map<String, dynamic>),
       invalidAfterReboot: OnvifUtil.mappedToBool(
           json['InvalidAfterReboot'] as Map<String, dynamic>),
-      timeout:
-          OnvifUtil.mappedToString(json['Timeout'] as Map<String, dynamic>),
+      timeout: OnvifUtil.mappedToString(json['Timeout']),
     );
 
 Map<String, dynamic> _$MediaUriToJson(MediaUri instance) => <String, dynamic>{

--- a/packages/easy_onvif/lib/src/model/ptz/duration_range.g.dart
+++ b/packages/easy_onvif/lib/src/model/ptz/duration_range.g.dart
@@ -8,8 +8,8 @@ part of 'duration_range.dart';
 
 DurationRange _$DurationRangeFromJson(Map<String, dynamic> json) =>
     DurationRange(
-      min: OnvifUtil.mappedToString(json['Min'] as Map<String, dynamic>),
-      max: OnvifUtil.mappedToString(json['Max'] as Map<String, dynamic>),
+      min: OnvifUtil.mappedToString(json['Min']),
+      max: OnvifUtil.mappedToString(json['Max']),
     );
 
 Map<String, dynamic> _$DurationRangeToJson(DurationRange instance) =>

--- a/packages/easy_onvif/lib/src/model/ptz/preset.g.dart
+++ b/packages/easy_onvif/lib/src/model/ptz/preset.g.dart
@@ -8,7 +8,7 @@ part of 'preset.dart';
 
 Preset _$PresetFromJson(Map<String, dynamic> json) => Preset(
       token: json['@token'] as String,
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
+      name: OnvifUtil.mappedToString(json['Name']),
       position: json['PTZPosition'] == null
           ? null
           : PtzVector.fromJson(json['PTZPosition'] as Map<String, dynamic>),

--- a/packages/easy_onvif/lib/src/model/ptz/set_preset_response.g.dart
+++ b/packages/easy_onvif/lib/src/model/ptz/set_preset_response.g.dart
@@ -8,8 +8,7 @@ part of 'set_preset_response.dart';
 
 SetPresetResponse _$SetPresetResponseFromJson(Map<String, dynamic> json) =>
     SetPresetResponse(
-      presetToken:
-          OnvifUtil.mappedToString(json['PresetToken'] as Map<String, dynamic>),
+      presetToken: OnvifUtil.mappedToString(json['PresetToken']),
     );
 
 Map<String, dynamic> _$SetPresetResponseToJson(SetPresetResponse instance) =>

--- a/packages/easy_onvif/lib/src/model/recordings/create_recording_job_response.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/create_recording_job_response.g.dart
@@ -9,7 +9,7 @@ part of 'create_recording_job_response.dart';
 CreateRecordingJobResponse _$CreateRecordingJobResponseFromJson(
         Map<String, dynamic> json) =>
     CreateRecordingJobResponse(
-      token: OnvifUtil.mappedToString(json['JobToken'] as Map<String, dynamic>),
+      token: OnvifUtil.mappedToString(json['JobToken']),
       jobConfiguration: RecordingJobConfiguration.fromJson(
           json['JobConfiguration'] as Map<String, dynamic>),
     );

--- a/packages/easy_onvif/lib/src/model/recordings/create_recording_response.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/create_recording_response.g.dart
@@ -9,8 +9,7 @@ part of 'create_recording_response.dart';
 CreateRecordingResponse _$CreateRecordingResponseFromJson(
         Map<String, dynamic> json) =>
     CreateRecordingResponse(
-      token: OnvifUtil.mappedToString(
-          json['RecordingToken'] as Map<String, dynamic>),
+      token: OnvifUtil.mappedToString(json['RecordingToken']),
     );
 
 Map<String, dynamic> _$CreateRecordingResponseToJson(

--- a/packages/easy_onvif/lib/src/model/recordings/filter.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/filter.g.dart
@@ -7,8 +7,8 @@ part of 'filter.dart';
 // **************************************************************************
 
 Filter _$FilterFromJson(Map<String, dynamic> json) => Filter(
-      topic: OnvifUtil.mappedToString(json['Topic'] as Map<String, dynamic>),
-      source: OnvifUtil.mappedToString(json['Source'] as Map<String, dynamic>),
+      topic: OnvifUtil.mappedToString(json['Topic']),
+      source: OnvifUtil.mappedToString(json['Source']),
     );
 
 Map<String, dynamic> _$FilterToJson(Filter instance) => <String, dynamic>{

--- a/packages/easy_onvif/lib/src/model/recordings/get_recording_jobs_response_item.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/get_recording_jobs_response_item.g.dart
@@ -9,8 +9,7 @@ part of 'get_recording_jobs_response_item.dart';
 GetRecordingJobsResponseItem _$GetRecordingJobsResponseItemFromJson(
         Map<String, dynamic> json) =>
     GetRecordingJobsResponseItem(
-      jobToken:
-          OnvifUtil.mappedToString(json['JobToken'] as Map<String, dynamic>),
+      jobToken: OnvifUtil.mappedToString(json['JobToken']),
       jobConfiguration: RecordingJobConfiguration.fromJson(
           json['JobConfiguration'] as Map<String, dynamic>),
     );

--- a/packages/easy_onvif/lib/src/model/recordings/get_recordings_response_item.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/get_recordings_response_item.g.dart
@@ -9,8 +9,7 @@ part of 'get_recordings_response_item.dart';
 GetRecordingsResponseItem _$GetRecordingsResponseItemFromJson(
         Map<String, dynamic> json) =>
     GetRecordingsResponseItem(
-      recordingToken: OnvifUtil.mappedToString(
-          json['RecordingToken'] as Map<String, dynamic>),
+      recordingToken: OnvifUtil.mappedToString(json['RecordingToken']),
       configuration: RecordingConfiguration.fromJson(
           json['Configuration'] as Map<String, dynamic>),
       tracks: GetTracksResponseList.fromJson(

--- a/packages/easy_onvif/lib/src/model/recordings/get_tracks_response_item.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/get_tracks_response_item.g.dart
@@ -9,8 +9,7 @@ part of 'get_tracks_response_item.dart';
 GetTracksResponseItem _$GetTracksResponseItemFromJson(
         Map<String, dynamic> json) =>
     GetTracksResponseItem(
-      trackToken:
-          OnvifUtil.mappedToString(json['TrackToken'] as Map<String, dynamic>),
+      trackToken: OnvifUtil.mappedToString(json['TrackToken']),
       configuration: TrackConfiguration.fromJson(
           json['Configuration'] as Map<String, dynamic>),
     );

--- a/packages/easy_onvif/lib/src/model/recordings/recording_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/recording_configuration.g.dart
@@ -11,10 +11,9 @@ RecordingConfiguration _$RecordingConfigurationFromJson(
     RecordingConfiguration(
       source: RecordingSourceInformation.fromJson(
           json['Source'] as Map<String, dynamic>),
-      content:
-          OnvifUtil.mappedToString(json['Content'] as Map<String, dynamic>),
-      maximumRetentionTime: OnvifUtil.mappedToString(
-          json['MaximumRetentionTime'] as Map<String, dynamic>),
+      content: OnvifUtil.mappedToString(json['Content']),
+      maximumRetentionTime:
+          OnvifUtil.mappedToString(json['MaximumRetentionTime']),
     );
 
 Map<String, dynamic> _$RecordingConfigurationToJson(

--- a/packages/easy_onvif/lib/src/model/recordings/recording_job_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/recording_job_configuration.g.dart
@@ -11,8 +11,7 @@ RecordingJobConfiguration _$RecordingJobConfigurationFromJson(
     RecordingJobConfiguration(
       scheduleToken: OnvifUtil.nullableMappedToString(
           json['ScheduleToken'] as Map<String, dynamic>?),
-      recordingToken: OnvifUtil.mappedToString(
-          json['RecordingToken'] as Map<String, dynamic>),
+      recordingToken: OnvifUtil.mappedToString(json['RecordingToken']),
       mode: RecordingJobConfiguration._recordingJobConfiguration(json['Mode']),
       priority: OnvifUtil.mappedToInt(json['Priority'] as Map<String, dynamic>),
       source: json['Source'] == null

--- a/packages/easy_onvif/lib/src/model/recordings/recording_job_state_information.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/recording_job_state_information.g.dart
@@ -9,9 +9,8 @@ part of 'recording_job_state_information.dart';
 RecordingJobStateInformation _$RecordingJobStateInformationFromJson(
         Map<String, dynamic> json) =>
     RecordingJobStateInformation(
-      recordingToken: OnvifUtil.mappedToString(
-          json['RecordingToken'] as Map<String, dynamic>),
-      state: OnvifUtil.mappedToString(json['State'] as Map<String, dynamic>),
+      recordingToken: OnvifUtil.mappedToString(json['RecordingToken']),
+      state: OnvifUtil.mappedToString(json['State']),
       sources: RecordingJobStateInformation._fromJson(json['Sources']),
       tracks: json['Tracks'] == null
           ? null

--- a/packages/easy_onvif/lib/src/model/recordings/recording_job_state_source.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/recording_job_state_source.g.dart
@@ -11,7 +11,7 @@ RecordingJobStateSource _$RecordingJobStateSourceFromJson(
     RecordingJobStateSource(
       sourceToken:
           SourceToken.fromJson(json['SourceToken'] as Map<String, dynamic>),
-      state: OnvifUtil.mappedToString(json['State'] as Map<String, dynamic>),
+      state: OnvifUtil.mappedToString(json['State']),
       tracks: Tracks.fromJson(json['Tracks'] as Map<String, dynamic>),
     );
 

--- a/packages/easy_onvif/lib/src/model/recordings/recording_source_information.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/recording_source_information.g.dart
@@ -9,15 +9,11 @@ part of 'recording_source_information.dart';
 RecordingSourceInformation _$RecordingSourceInformationFromJson(
         Map<String, dynamic> json) =>
     RecordingSourceInformation(
-      sourceId:
-          OnvifUtil.mappedToString(json['SourceId'] as Map<String, dynamic>),
-      name: OnvifUtil.mappedToString(json['Name'] as Map<String, dynamic>),
-      location:
-          OnvifUtil.mappedToString(json['Location'] as Map<String, dynamic>),
-      description:
-          OnvifUtil.mappedToString(json['Description'] as Map<String, dynamic>),
-      address:
-          OnvifUtil.mappedToString(json['Address'] as Map<String, dynamic>),
+      sourceId: OnvifUtil.mappedToString(json['SourceId']),
+      name: OnvifUtil.mappedToString(json['Name']),
+      location: OnvifUtil.mappedToString(json['Location']),
+      description: OnvifUtil.mappedToString(json['Description']),
+      address: OnvifUtil.mappedToString(json['Address']),
     );
 
 Map<String, dynamic> _$RecordingSourceInformationToJson(

--- a/packages/easy_onvif/lib/src/model/recordings/source_token.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/source_token.g.dart
@@ -8,7 +8,7 @@ part of 'source_token.dart';
 
 SourceToken _$SourceTokenFromJson(Map<String, dynamic> json) => SourceToken(
       type: json['@Type'] as String?,
-      token: OnvifUtil.mappedToString(json['Token'] as Map<String, dynamic>),
+      token: OnvifUtil.mappedToString(json['Token']),
     );
 
 Map<String, dynamic> _$SourceTokenToJson(SourceToken instance) =>

--- a/packages/easy_onvif/lib/src/model/recordings/track.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/track.g.dart
@@ -7,10 +7,8 @@ part of 'track.dart';
 // **************************************************************************
 
 Track _$TrackFromJson(Map<String, dynamic> json) => Track(
-      sourceTag:
-          OnvifUtil.mappedToString(json['SourceTag'] as Map<String, dynamic>),
-      destination:
-          OnvifUtil.mappedToString(json['Destination'] as Map<String, dynamic>),
+      sourceTag: OnvifUtil.mappedToString(json['SourceTag']),
+      destination: OnvifUtil.mappedToString(json['Destination']),
       error: OnvifUtil.nullableMappedToString(
           json['Error'] as Map<String, dynamic>?),
       state: Track._nullableRecordingJobState(json['State']),

--- a/packages/easy_onvif/lib/src/model/recordings/track_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/recordings/track_configuration.g.dart
@@ -9,8 +9,7 @@ part of 'track_configuration.dart';
 TrackConfiguration _$TrackConfigurationFromJson(Map<String, dynamic> json) =>
     TrackConfiguration(
       trackType: TrackConfiguration._trackType(json['TrackType']),
-      description:
-          OnvifUtil.mappedToString(json['Description'] as Map<String, dynamic>),
+      description: OnvifUtil.mappedToString(json['Description']),
     );
 
 Map<String, dynamic> _$TrackConfigurationToJson(TrackConfiguration instance) =>

--- a/packages/easy_onvif/lib/src/model/replay/capabilities.g.dart
+++ b/packages/easy_onvif/lib/src/model/replay/capabilities.g.dart
@@ -9,11 +9,10 @@ part of 'capabilities.dart';
 Capabilities _$CapabilitiesFromJson(Map<String, dynamic> json) => Capabilities(
       reversePlayback:
           OnvifUtil.stringToBool(json['@ReversePlayback'] as String),
-      sessionTimeoutRange: OnvifUtil.mappedToString(
-          json['@SessionTimeoutRange'] as Map<String, dynamic>),
+      sessionTimeoutRange:
+          OnvifUtil.mappedToString(json['@SessionTimeoutRange']),
       rtpRtspTcp: OnvifUtil.stringToBool(json['@RTP_RTSP_TCP'] as String),
-      rtspWebSocketUri: OnvifUtil.mappedToString(
-          json['@RTSPWebSocketUri'] as Map<String, dynamic>),
+      rtspWebSocketUri: OnvifUtil.mappedToString(json['@RTSPWebSocketUri']),
     );
 
 Map<String, dynamic> _$CapabilitiesToJson(Capabilities instance) =>

--- a/packages/easy_onvif/lib/src/model/replay/get_replay_uri_response.g.dart
+++ b/packages/easy_onvif/lib/src/model/replay/get_replay_uri_response.g.dart
@@ -9,7 +9,7 @@ part of 'get_replay_uri_response.dart';
 GetReplayUriResponse _$GetReplayUriResponseFromJson(
         Map<String, dynamic> json) =>
     GetReplayUriResponse(
-      uri: OnvifUtil.mappedToString(json['Uri'] as Map<String, dynamic>),
+      uri: OnvifUtil.mappedToString(json['Uri']),
     );
 
 Map<String, dynamic> _$GetReplayUriResponseToJson(

--- a/packages/easy_onvif/lib/src/model/replay/replay_configuration.g.dart
+++ b/packages/easy_onvif/lib/src/model/replay/replay_configuration.g.dart
@@ -8,8 +8,7 @@ part of 'replay_configuration.dart';
 
 ReplayConfiguration _$ReplayConfigurationFromJson(Map<String, dynamic> json) =>
     ReplayConfiguration(
-      sessionTimeout: OnvifUtil.mappedToString(
-          json['SessionTimeout'] as Map<String, dynamic>),
+      sessionTimeout: OnvifUtil.mappedToString(json['SessionTimeout']),
     );
 
 Map<String, dynamic> _$ReplayConfigurationToJson(

--- a/packages/easy_onvif/lib/src/model/search/find_recordings_response.g.dart
+++ b/packages/easy_onvif/lib/src/model/search/find_recordings_response.g.dart
@@ -9,8 +9,7 @@ part of 'find_recordings_response.dart';
 FindRecordingsResponse _$FindRecordingsResponseFromJson(
         Map<String, dynamic> json) =>
     FindRecordingsResponse(
-      searchToken:
-          OnvifUtil.mappedToString(json['SearchToken'] as Map<String, dynamic>),
+      searchToken: OnvifUtil.mappedToString(json['SearchToken']),
     );
 
 Map<String, dynamic> _$FindRecordingsResponseToJson(

--- a/packages/easy_onvif/lib/src/model/search/recording_information.g.dart
+++ b/packages/easy_onvif/lib/src/model/search/recording_information.g.dart
@@ -9,16 +9,14 @@ part of 'recording_information.dart';
 RecordingInformation _$RecordingInformationFromJson(
         Map<String, dynamic> json) =>
     RecordingInformation(
-      recordingToken: OnvifUtil.mappedToString(
-          json['RecordingToken'] as Map<String, dynamic>),
+      recordingToken: OnvifUtil.mappedToString(json['RecordingToken']),
       source: RecordingSourceInformation.fromJson(
           json['Source'] as Map<String, dynamic>),
       earliestRecording: OnvifUtil.mappedToStdDateTime(
           json['EarliestRecording'] as Map<String, dynamic>),
       latestRecording: OnvifUtil.mappedToStdDateTime(
           json['LatestRecording'] as Map<String, dynamic>),
-      content:
-          OnvifUtil.mappedToString(json['Content'] as Map<String, dynamic>),
+      content: OnvifUtil.mappedToString(json['Content']),
       tracks: RecordingInformation._fromJson(json['Track']),
       recordingStatus:
           RecordingInformation._recordingStatus(json['RecordingStatus']),

--- a/packages/easy_onvif/lib/src/model/search/track_information.g.dart
+++ b/packages/easy_onvif/lib/src/model/search/track_information.g.dart
@@ -8,11 +8,9 @@ part of 'track_information.dart';
 
 TrackInformation _$TrackInformationFromJson(Map<String, dynamic> json) =>
     TrackInformation(
-      trackToken:
-          OnvifUtil.mappedToString(json['TrackToken'] as Map<String, dynamic>),
+      trackToken: OnvifUtil.mappedToString(json['TrackToken']),
       trackType: TrackInformation._trackType(json['TrackType']),
-      description:
-          OnvifUtil.mappedToString(json['Description'] as Map<String, dynamic>),
+      description: OnvifUtil.mappedToString(json['Description']),
       dataFrom: OnvifUtil.mappedToStdDateTime(
           json['DataFrom'] as Map<String, dynamic>),
       dataTo:

--- a/packages/easy_onvif/lib/src/util/util.dart
+++ b/packages/easy_onvif/lib/src/util/util.dart
@@ -129,7 +129,8 @@ class OnvifUtil {
   static double? nullableMappedToDouble(Map<String, dynamic>? value) =>
       value != null ? mappedToDouble(value) : null;
 
-  static String mappedToString(Map<String, dynamic> value) => value['\$'];
+  static String mappedToString(dynamic value) =>
+      value is String ? value : value['\$'];
 
   static ReferenceToken mappedToReferenceToken(Map<String, dynamic> value) =>
       ReferenceToken(value['\$']);


### PR DESCRIPTION
Fixed an issue with the `mappedToString` function where it only handled `Map<String, dynamic>` inputs. Updated the function to support both `String` and `Map<String, dynamic>` types, ensuring consistent handling of the `Name` parameter during deserialization. An exception is thrown for unsupported types.

Fixes #68 